### PR TITLE
user-activity heatmap component and page - final version

### DIFF
--- a/components/ActivityGraph/UserActivityGraph.module.css
+++ b/components/ActivityGraph/UserActivityGraph.module.css
@@ -1,0 +1,101 @@
+.graphContainer {
+  display: grid;
+  grid-template-columns: repeat(52,20px); /* Adjust the width of the tiles */
+  grid-template-rows: repeat(7, 20px); /* Adjust the height of the tiles */
+  gap: 1.3px;
+  background-color: #f5f5f5;
+  padding: 11px;
+  border-radius: 10px;
+  border:1px solid #E4E4E4;
+  box-shadow: 0px 2px 5px rgba(0, 0, 0, 0.15);
+}
+
+.tile {
+  background-color: #ffffff;
+  transition: background-color 0.3s;
+  width: 100%;
+  height: 100%;
+}
+
+.activityTile {
+  transition: background-color 0.3s;
+  width: 100%;
+  height: 100%;
+}
+
+.tooltip {
+  background-color: #ffffff;
+  color: #000000;
+  padding: 5px;
+  border-radius: 4px;
+  font-size: 12px;
+  font-weight: normal;
+  box-shadow: 0px 2px 5px rgba(0, 0, 0, 0.15);
+}
+
+.dayLabel {
+  position: absolute;
+  top: -20px;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: 12px;
+  font-weight: bold;
+}
+
+.monthLabel {
+  position: absolute;
+  bottom: -20px;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: 12px;
+  font-weight: bold;
+  text-align: center; /* Center align the month labels */
+}
+
+.legendContainer {
+  display: flex;
+  align-items: center;
+  margin-top: 10px;
+  flex-direction: row-reverse;
+}
+
+.legendTile {
+  width: 20px;
+  height: 20px;
+  margin-right: 5px;
+}
+
+.legendText {
+  font-size: 12px;
+  font-weight: normal;
+  padding: 5px;
+  text-align: right; /* Align the legend text to the right */
+}
+.buttonContainer {
+  flex-grow: 1; /* Allows the button to take up the remaining space */
+  text-align: left; /* Align the button to the left */
+  margin-right: 10px; /* Add some spacing to the right of the button */
+}
+
+.modal {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background-color: #ffffff;
+  padding: 20px;
+  border-radius: 4px;
+  box-shadow: 0px 2px 5px rgba(0, 0, 0, 0.15);
+  outline: none;
+  width: 400px;
+  max-width: 90%;  
+}
+
+.modal h2 {
+  margin-top: 0;
+  text-align: left;
+}
+
+.modal p {
+  margin-bottom: 20px;
+}

--- a/components/ActivityGraph/UserActivityGraph.tsx
+++ b/components/ActivityGraph/UserActivityGraph.tsx
@@ -1,0 +1,212 @@
+import React, { useState } from 'react';
+import { Tooltip, Modal, Button } from '@mui/material';
+import { format } from 'date-fns';
+import classes from './UserActivityGraph.module.css';
+
+interface UserActivityGraphProps {
+    data: { date: Date; activityCount: number }[];
+    registrationDate: Date;
+}
+
+const UserActivityGraph: React.FC<UserActivityGraphProps> = ({
+    data,
+    registrationDate,
+}) => {
+    const [modalOpen, setModalOpen] = useState(false);
+    const [hoveredLegend, setHoveredLegend] = useState<string | null>(null);
+
+    const handleModalOpen = () => {
+        setModalOpen(true);
+    };
+
+    const handleModalClose = () => {
+        setModalOpen(false);
+    };
+
+    const handleLegendTileHover = (color: string) => {
+        setHoveredLegend(color);
+    };
+
+    // Labels
+    const days = ['Mon', 'Wed', 'Fri', 'Sun'];
+    const months = [
+        'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+        'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'
+    ];
+
+
+    // Helper to get date for a tile 
+    const getDateForTile = (weekIndex: number, dayIndex: number) => {
+
+        const currentDate = new Date();
+
+        // Registeration day details
+        const registrationDay = registrationDate.getDay();
+        // const registrationMonth = registrationDate.getMonth();
+
+        return new Date(
+            currentDate.getFullYear(),
+            currentDate.getMonth(),
+            currentDate.getDate() -
+            (52 - weekIndex) * 7 +
+            dayIndex -
+            registrationDay
+        );
+
+    }
+
+    const getTileColor = (activityCount: number): string => {
+        if (activityCount === 0) {
+            return '#ebedf0';
+        } else if (activityCount >= 1 && activityCount <= 3) {
+            return '#c6e48b';
+        } else if (activityCount >= 4 && activityCount <= 6) {
+            return '#7bc96f';
+        } else if (activityCount >= 7 && activityCount <= 9) {
+            return '#239a3b';
+        } else {
+            return '#196127';
+        }
+    };
+
+    const getTileTooltip = (
+        date: Date,
+        activityCount: number,
+        isFirstDay: boolean
+    ): string => {
+        const formattedDate = format(date, 'EEEE, MMMM d, yyyy');
+        if (isFirstDay) {
+            return `First Day, \n${formattedDate}`;
+        } else {
+            return `${formattedDate}\n${activityCount} activities`;
+        }
+    };
+
+    const renderLegendTiles = () => {
+        const legendColors = ['#196127', '#239a3b', '#7bc96f', '#c6e48b', '#ebedf0'];
+
+        return legendColors.map((color) => {
+            const activityCount = getActivityCountForColor(color);
+            const tooltipContent =
+                hoveredLegend === color
+                    ? activityCount === 0
+                        ? 'No Activities'
+                        : `${activityCount}+ activities`
+                    : '';
+
+            return (
+                <Tooltip key={color} title={tooltipContent} arrow>
+                    <div
+                        className={classes.legendTile}
+                        style={{ backgroundColor: color }}
+                        onMouseEnter={() => handleLegendTileHover(color)}
+                        onMouseLeave={() => handleLegendTileHover('null')}
+                    />
+                </Tooltip>
+            );
+        });
+    };
+
+    const getActivityCountForColor = (color: string): number => {
+        // Map legend colors to activity count using your getTileColor function
+        switch (color) {
+            case '#ebedf0':
+                return 0;
+            case '#c6e48b':
+                return 1; // Adjust the counts as per your getTileColor logic
+            case '#7bc96f':
+                return 3;
+            case '#239a3b':
+                return 6;
+            case '#196127':
+                return 10;
+            default:
+                return 0; // Default to 0 for unknown colors
+        }
+    };
+
+
+    const renderTiles = () => {
+        const tiles = [];
+
+        for (let i = 0; i < 52; i++) {
+            for (let j = 0; j < 7; j++) {
+                const date = getDateForTile(i, j);
+
+                // Get day and month labels
+                const dayLabel = days[j];
+                const monthLabel = months[date.getMonth()];
+
+
+                const activityData = data.find(
+                    (item) =>
+                        item.date.getFullYear() === date.getFullYear() &&
+                        item.date.getMonth() === date.getMonth() &&
+                        item.date.getDate() === date.getDate()
+                );
+                const activityCount = activityData ? activityData.activityCount : 0;
+                const isFirstDay =
+                    date.getFullYear() === registrationDate.getFullYear() &&
+                    date.getMonth() === registrationDate.getMonth() &&
+                    date.getDate() === registrationDate.getDate();
+
+                const tileColor = getTileColor(activityCount);
+
+                const tileTooltip = getTileTooltip(date, activityCount, isFirstDay);
+
+                const tileClass = isFirstDay
+                    ? classes.firstDayTile
+                    : activityCount === 0
+                        ? classes.tile
+                        : `${classes.tile} ${classes.activityTile}`;
+
+                tiles.push(
+                    <Tooltip key={`${i}-${j}`} title={tileTooltip} arrow>
+                        <div className={tileClass} style={{ backgroundColor: tileColor }}>
+                            {!isFirstDay && (
+                                <>
+                                    <div className={classes.dayLabel}>{dayLabel}</div>
+                                    <div className={classes.monthLabel}>{monthLabel}</div>
+                                </>
+                            )}
+                        </div>
+                    </Tooltip>
+                );
+
+
+            }
+        }
+
+        return tiles;
+    };
+
+    return (
+        <div className={classes.main}>
+            <div className={classes.graphContainer}>{renderTiles()}</div>
+            <div className={classes.legendContainer}>
+                <span className={classes.legendText}>More</span>
+                {renderLegendTiles()}
+                <span className={classes.legendText}>Less</span>
+                <div className={classes.buttonContainer}>
+                    <Button onClick={handleModalOpen}>What is this?</Button>
+                </div>
+                <Modal
+                    open={modalOpen}
+                    onClose={handleModalClose}
+                    aria-labelledby="modal-title"
+                    aria-describedby="modal-description"
+                >
+                    <div className={classes.modal}>
+                        <h2 id="modal-title">Daily Activity</h2>
+                        <p id="modal-description">
+                            Daily Activity refers to the number of activities performed by a user on a given day. It is represented by the color of the tiles in the graph. The darker the color, the higher the activity count. The graph displays the activity count for each day of the week over a period of 52 weeks. The legend on the right side of the graph provides a color scale to interpret the activity levels. You can hover over each tile to view the specific date and activity count. Enjoy tracking your daily activities!
+                        </p>
+                        <Button onClick={handleModalClose}>Close</Button>
+                    </div>
+                </Modal>
+            </div>
+        </div>
+    );
+};
+
+export default UserActivityGraph;

--- a/components/Heatmap/Heatmap.module.css
+++ b/components/Heatmap/Heatmap.module.css
@@ -170,9 +170,10 @@
   position: absolute;
   bottom: 0;
   right: 0;
-  /* letter-spacing: 0; */
   box-sizing: inherit;
   display: flex;
+  padding: 15px;
+  gap: 0.8px;
   align-items: center;
   flex-direction: row-reverse;
 }
@@ -180,37 +181,37 @@
 .legendTile {
   width: 11px;
   height: 11px;
-  margin-right: 5px;
+  margin-right: 2px;
 }
 
 .legendText {
-  font-size: 12px;
+  font-size: 13px;
+  line-height: 1.5;
+  color: rgb(144, 144, 144);
   font-weight: normal;
-  padding: 5px;
+  padding: 10px;
 }
 
 .modalContainer{
   box-sizing: inherit;
+  
 }
 
 .buttonContainer {
   margin-right: 50px;
   position: absolute;
+  padding: 15px;
   bottom: 0;
   left: 0;
 }
 
 .btn {
-  -webkit-font-smoothing: antialiased;
   cursor: pointer;
-  user-select: none;
-  -webkit-tap-highlight-color: transparent;
-  letter-spacing: 0.02857em;
+  padding: 10px;
   text-transform: inherit;
   box-sizing: inherit;
   opacity: 1;
   color: #909090;
-  margin: 0;
   font-family: 'Roboto', 'Helvetica', 'Arial', sans-serif;
   font-weight: normal;
   font-style: normal;

--- a/components/Heatmap/Heatmap.module.css
+++ b/components/Heatmap/Heatmap.module.css
@@ -1,0 +1,215 @@
+/* Wrapper styles */
+.Wrapper {
+  color: #202124;
+  font-family: "Roboto", "Helvetica", "Arial", sans-serif;
+  font-weight: 400;
+  line-height: 1.43;
+  letter-spacing: 0;
+  box-sizing: inherit;
+  font-size: 13px;
+  fill: #909090;
+  margin-bottom: 8px;
+  user-select: none;
+}
+
+/* Graph styles */
+.Graph {
+  padding: 20px;
+  border-radius: 10px;
+  border: 1px solid #E4E4E4;
+  box-shadow: 0px 2px 5px rgba(0, 0, 0, 0.15);
+  margin: auto 80px;
+  display: inline-grid;
+  grid-template-areas:
+    'empty months'
+    'days squares';
+  grid-template-columns: auto 1fr;
+  grid-gap: 10px;
+}
+
+.header {
+  -webkit-font-smoothing: antialiased;
+  letter-spacing: 0;
+  box-sizing: inherit;
+  color: #202124;
+  margin: 20px 80px;
+  padding-top: 5px;
+  font-family: 'Roboto', 'Helvetica', 'Arial', sans-serif;
+  font-size: 16px;
+  font-weight: bold;
+  line-height: 1.5;
+}
+
+/* Months styles */
+.Months {
+  padding-inline-start: 0;
+  grid-area: months;
+  margin-bottom: 0;
+  display: grid;
+  grid-template-columns:
+    calc(19px * 4) /* jan */
+    calc(19px * 4) /* feb */
+    calc(19px * 4) /* mar */
+    calc(19px * 5) /* apr */
+    calc(19px * 4) /* may */
+    calc(19px * 4) /* jun */
+    calc(19px * 5) /* jul */
+    calc(19px * 4) /* aug */
+    calc(19px * 4) /* sep */
+    calc(19px * 5) /* oct */
+    calc(19px * 4) /* nov */
+    calc(19px * 5) /* dec */;
+}
+
+/* Days styles */
+.Days {
+  margin-block-end: 0;
+  margin-block-start: 0;
+  grid-area: days;
+  display: grid;
+  top: 12px;
+  grid-gap: 4px; /* Set your square gap here */
+  grid-template-rows: repeat(7, 25px); /* Set your square size here */
+}
+
+/* SquaresList styles */
+.SquaresList {
+  margin-top: 0;
+  margin-block-start: 0;
+  grid-area: squares;
+  display: grid;
+  grid-gap: 4px; /* Set your square gap here */
+  grid-template-rows: repeat(7, 15px); /* Set your square size here */
+  z-index: 1;
+  grid-auto-flow: column;
+  grid-auto-columns: 15px; /* Set your square size here */
+}
+
+/* SquareListItem styles */
+.SquareListItem {
+  border-radius: 3px;
+  border: 1px rgba(27, 31, 35, 0.06) solid;
+  background-color: #ebedf0; /* Default color */
+}
+
+.SquareListItem[data-level='1'] {
+  background-color: #c6e48b;
+}
+
+.SquareListItem[data-level='2'] {
+  background-color: #40c463;
+}
+
+.SquareListItem[data-level='3'] {
+  background-color: #30a14e;
+}
+
+.SquareListItem[data-level='4'] {
+  background-color: #216e39;
+}
+
+/* Tooltip styles */
+.SquareListItem[data-tooltip] {
+  position: relative;
+  cursor: pointer;
+}
+
+.SquareListItem[data-tooltip]:before,
+.SquareListItem[data-tooltip]:after {
+  visibility: hidden;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.SquareListItem[data-tooltip]:before {
+  position: absolute;
+  z-index: 999;
+  bottom: 150%;
+  left: 100%;
+  margin-bottom: 5px;
+  margin-left: -90px;
+  padding: 7px;
+  width: 150px;
+  border-radius: 3px;
+  background-color: #000;
+  background-color: hsla(0, 0%, 20%, 0.9);
+  color: #fff;
+  content: attr(data-tooltip);
+  text-align: center;
+  font-size: 10px;
+  line-height: 1.2;
+}
+
+.SquareListItem[data-tooltip]:after {
+  position: absolute;
+  bottom: 150%;
+  left: 50%;
+  margin-left: -5px;
+  width: 0;
+  border-top: 5px solid hsla(0, 0%, 20%, 0.9);
+  border-right: 5px solid transparent;
+  border-left: 5px solid transparent;
+  content: ' ';
+  font-size: 0;
+  line-height: 0;
+  z-index: inherit;
+}
+
+.SquareListItem[data-tooltip]:hover:before,
+.SquareListItem[data-tooltip]:hover:after {
+  visibility: visible;
+  opacity: 1;
+}
+
+.legendContainer {
+  display: flex;
+  align-items: center;
+  margin-top: 10px;
+  margin-right: 260px;
+  flex-direction: row-reverse;
+}
+
+.legendTile {
+  width: 20px;
+  height: 20px;
+  margin-right: 5px;
+}
+
+.legendText {
+  font-size: 12px;
+  font-weight: normal;
+  padding: 5px;
+}
+
+.buttonContainer {
+  flex-grow: 1; /* Allows the button to take up the remaining space */
+  text-align: left; /* Align the button to the left */
+  margin-left: 70px; /* Add some spacing to the right of the button */
+}
+
+.modalBtn {
+  margin: 20px 80px;
+}
+
+.modal {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background-color: #ffffff;
+  padding: 20px;
+  border-radius: 4px;
+  box-shadow: 0px 2px 5px rgba(0, 0, 0, 0.15);
+  outline: none;
+  width: 400px;
+  max-width: 90%;
+}
+
+.modal h2 {
+  margin-top: 0;
+  text-align: left;
+}
+
+.modal p {
+  margin-bottom: 20px;
+}

--- a/components/Heatmap/Heatmap.module.css
+++ b/components/Heatmap/Heatmap.module.css
@@ -99,7 +99,8 @@
 }
 
 .SquareListItem[data-level='1'] {
-  background-color: rgba(0,143,83,0.3);
+  fill: rgba(0,143,83,1);
+  /* background-color: rgba(0,143,83,0.3); */
 }
 
 .SquareListItem[data-level='2'] {

--- a/components/Heatmap/Heatmap.module.css
+++ b/components/Heatmap/Heatmap.module.css
@@ -1,24 +1,35 @@
+.main{
+  position: relative;
+  padding: 10px;
+  border-radius: 10px;
+  border: 1px solid #E4E4E4;
+  box-shadow: 0px 2px 5px rgba(0, 0, 0, 0.15);
+  margin: auto 80px;
+  display: inline-grid;
+  grid-template-columns: auto 1fr;
+  grid-gap: 10px;
+}
+
 /* Wrapper styles */
-.Wrapper {
-  color: #202124;
+.GraphWrapper {
+  position: relative;
+  fill: #909090 !important;
   font-family: "Roboto", "Helvetica", "Arial", sans-serif;
-  font-weight: 400;
   line-height: 1.43;
   letter-spacing: 0;
   box-sizing: inherit;
   font-size: 13px;
-  fill: #909090;
-  margin-bottom: 8px;
   user-select: none;
 }
 
 /* Graph styles */
 .Graph {
+  position: relative;
   padding: 20px;
   border-radius: 10px;
-  border: 1px solid #E4E4E4;
-  box-shadow: 0px 2px 5px rgba(0, 0, 0, 0.15);
-  margin: auto 80px;
+  border: 0px solid #E4E4E4;
+  box-shadow: 0px 2px 5px rgba(255, 255, 255, 0.15);
+  margin: 5px;
   display: inline-grid;
   grid-template-areas:
     'empty months'
@@ -28,16 +39,11 @@
 }
 
 .header {
-  -webkit-font-smoothing: antialiased;
-  letter-spacing: 0;
-  box-sizing: inherit;
   color: #202124;
   margin: 20px 80px;
-  padding-top: 5px;
-  font-family: 'Roboto', 'Helvetica', 'Arial', sans-serif;
   font-size: 16px;
   font-weight: bold;
-  line-height: 1.5;
+  line-height: 1.2;
 }
 
 /* Months styles */
@@ -89,29 +95,28 @@
 .SquareListItem {
   border-radius: 3px;
   border: 1px rgba(27, 31, 35, 0.06) solid;
-  background-color: #ebedf0; /* Default color */
+  background-color: #E4E4E4; /* Default color */
 }
 
 .SquareListItem[data-level='1'] {
-  background-color: #c6e48b;
+  background-color: rgba(0,143,83,0.3);
 }
 
 .SquareListItem[data-level='2'] {
-  background-color: #40c463;
+  background-color: rgba(0,143,83,0.5);
 }
 
 .SquareListItem[data-level='3'] {
-  background-color: #30a14e;
+  background-color: rgba(0,143,83,0.7);
 }
 
 .SquareListItem[data-level='4'] {
-  background-color: #216e39;
+  background-color: rgba(0,143,83,1);
 }
 
 /* Tooltip styles */
 .SquareListItem[data-tooltip] {
   position: relative;
-  cursor: pointer;
 }
 
 .SquareListItem[data-tooltip]:before,
@@ -162,16 +167,19 @@
 }
 
 .legendContainer {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  /* letter-spacing: 0; */
+  box-sizing: inherit;
   display: flex;
   align-items: center;
-  margin-top: 10px;
-  margin-right: 260px;
   flex-direction: row-reverse;
 }
 
 .legendTile {
-  width: 20px;
-  height: 20px;
+  width: 11px;
+  height: 11px;
   margin-right: 5px;
 }
 
@@ -181,14 +189,37 @@
   padding: 5px;
 }
 
-.buttonContainer {
-  flex-grow: 1; /* Allows the button to take up the remaining space */
-  text-align: left; /* Align the button to the left */
-  margin-left: 70px; /* Add some spacing to the right of the button */
+.modalContainer{
+  box-sizing: inherit;
 }
 
-.modalBtn {
-  margin: 20px 80px;
+.buttonContainer {
+  margin-right: 50px;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+}
+
+.btn {
+  -webkit-font-smoothing: antialiased;
+  cursor: pointer;
+  user-select: none;
+  -webkit-tap-highlight-color: transparent;
+  letter-spacing: 0.02857em;
+  text-transform: inherit;
+  box-sizing: inherit;
+  opacity: 1;
+  color: #909090;
+  margin: 0;
+  font-family: 'Roboto', 'Helvetica', 'Arial', sans-serif;
+  font-weight: normal;
+  font-style: normal;
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.btn:hover {
+  text-decoration: underline;
 }
 
 .modal {
@@ -208,6 +239,8 @@
 .modal h2 {
   margin-top: 0;
   text-align: left;
+  font-weight: bolder;
+
 }
 
 .modal p {

--- a/components/Heatmap/Heatmap.test.tsx
+++ b/components/Heatmap/Heatmap.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { render } from '@testing-library/react'
 import { getRandomCount } from './utils'
-import { DAYS_IN_YEAR } from '../constants'
+import { DAYS_IN_YEAR } from './constants'
 
 import Heatmap from './Heatmap'
 

--- a/components/Heatmap/Heatmap.test.tsx
+++ b/components/Heatmap/Heatmap.test.tsx
@@ -1,0 +1,12 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import { getRandomCount } from './utils'
+import { DAYS_IN_YEAR } from '../constants'
+
+import Heatmap from './Heatmap'
+
+describe('Heatmap', () => {
+    test('renders the Heatmap component', () => {
+        render(<Heatmap count={getRandomCount(DAYS_IN_YEAR)} />)
+    })
+})

--- a/components/Heatmap/Heatmap.tsx
+++ b/components/Heatmap/Heatmap.tsx
@@ -58,7 +58,7 @@ const Heatmap: React.FC<HeatmapProps> = (props: HeatmapProps) => {
 
 
 	const renderLegendTiles = () => {
-		const legendColors = ['#196127', '#239a3b', '#7bc96f', '#c6e48b', '#ebedf0'];
+		const legendColors = ['rgba(0,143,83,1)', 'rgba(0,143,83,0.7)', 'rgba(0,143,83,0.5)', 'rgba(0,143,83,0.3)', '#E4E4E4'];
 
 		return legendColors.map((color) => {
 			const activityCount = getActivityCountForColor(color);
@@ -85,132 +85,81 @@ const Heatmap: React.FC<HeatmapProps> = (props: HeatmapProps) => {
 	const getActivityCountForColor = (color: string): number => {
 		// Map legend colors to activity count using your getTileColor function
 		switch (color) {
-			case '#ebedf0':
+			case '#E4E4E4':
 				return 0;
-			case '#c6e48b':
+			case 'rgba(0,143,83,0.3)':
 				return 1; // Adjust the counts as per your getTileColor logic
-			case '#7bc96f':
+			case 'rgba(0,143,83,0.5)':
 				return 3;
-			case '#239a3b':
+			case 'rgba(0,143,83,0.7)':
 				return 6;
-			case '#196127':
+			case 'rgba(0,143,83,1)':
 				return 10;
 			default:
 				return 0; // Default to 0 for unknown colors
 		}
 	};
 
-	// const renderTiles = () => {
-	// 	const tiles = [];
-
-	// 	for (let i = 0; i < 52; i++) {
-	// 		for (let j = 0; j < 7; j++) {
-	// 			const date = getDateForTile(i, j);
-	// 			const registrationDate = new Date(2023, 0, 1);
-
-	// 			if (date < registrationDate) {
-	// 				tiles.push(<div className={styles.placeholderTile} />);
-	// 				continue;
-	// 			}
-
-	// 			const activityData = props.data.find(
-	// 				(item) =>
-	// 					item.date.getFullYear() === date.getFullYear() &&
-	// 					item.date.getMonth() === date.getMonth() &&
-	// 					item.date.getDate() === date.getDate()
-	// 			);
-
-	// 			const isFirstDay = date.getTime() === registrationDate.getTime();
-	// 			const activityCount = activityData ? activityData.activityCount : 0;
-	// 			const tileColor = getTileColor(activityCount);
-
-	// 			tiles.push(
-	// 				<Tooltip title={getTileTooltip(date, activityCount, isFirstDay)}>
-	// 					<div
-	// 						className={styles.activityTile}
-	// 						style={{ backgroundColor: tileColor }}
-	// 					>
-	// 						{/* Added day and month labels */}
-	// 						{!isFirstDay && (
-	// 							<>
-	// 								<div className={styles.dayLabel}>
-	// 									{WEEK_DAYS[j]}
-	// 								</div>
-	// 								<div className={styles.monthLabel}>
-	// 									{MONTHS[date.getMonth()]}
-	// 								</div>
-	// 							</>
-	// 						)}
-	// 					</div>
-	// 				</Tooltip>
-	// 			);
-	// 		}
-	// 	}
-	// 	return tiles;
-	// };
-
 	return (
-		<div className={styles.Wrapper}>
-			<div className={styles.header}>
-				<p>Activity</p>
-			</div>
-			<div className={styles.Graph}>
-				<ul className={styles.Months}>
-					{MONTHS.map((month, i) => (
-						<li key={i}>{month}</li>
-					))}
-				</ul>
-				<ul className={styles.Days}>
-					{WEEK_DAYS.map((day, i) => (
-						<li key={i}>{day}</li>
-					))}
-				</ul>
-				<ul className={styles.SquaresList}>
-					{[...Array(squareNumber)].map((key: React.Key, i) => (
-						<li
-							className={`${styles.SquareListItem} ${styles.squares}`}
-							data-level={level[i]}
-							key={key}
-							data-tooltip={
-								props.tooltipContent || `${count[i]} activities`
-							}
-						></li>
-					))}
-				</ul>
-			</div>
-
-			<div className={styles.legendContainer}>
-				<span className={styles.legendText}>More</span>
-				{renderLegendTiles()}
-				<span className={styles.legendText}>Less</span>
-
-				<div className={styles.buttonContainer}>
-					<Button onClick={handleModalOpen}>What is this?</Button>
-				</div>
-				<Modal
-					open={modalOpen}
-					onClose={handleModalClose}
-					aria-labelledby="modal-title"
-					aria-describedby="modal-description"
-				>
-					<div>
-						<div className={styles.modal}>
-							<h2 id="modal-title">Daily Activity</h2>
-							<p id="modal-description">
-								Daily Activity refers to the number of activities performed by a
-								user on a given day. It is represented by the color of the tiles
-								in the graph. The darker the color, the higher the activity count.
-								The graph displays the activity count for each day of the week over
-								a period of 52 weeks. The legend on the right side of the graph
-								provides a color scale to interpret the activity levels. You can
-								hover over each tile to view the specific date and activity count.
-								Enjoy tracking your daily activities!
-							</p>
-
-							<Button onClick={handleModalClose}>Close</Button>
-						</div>
+		<div>
+			<p className={styles.header}>Activity</p>
+			<div className={styles.main}>
+				<div className={styles.GraphWrapper}>
+					<div className={styles.Graph}>
+						<ul className={styles.Months}>
+							{MONTHS.map((month, i) => (
+								<li key={i}>{month}</li>
+							))}
+						</ul>
+						<ul className={styles.Days}>
+							{WEEK_DAYS.map((day, i) => (
+								<li key={i}>{day}</li>
+							))}
+						</ul>
+						<ul className={styles.SquaresList}>
+							{[...Array(squareNumber)].map((key: React.Key, i) => (
+								<li
+									className={`${styles.SquareListItem} ${styles.squares}`}
+									data-level={level[i]}
+									key={key}
+									data-tooltip={
+										props.tooltipContent || `${count[i]} activities`
+									}
+								></li>
+							))}
+						</ul>
 					</div>
-				</Modal>
+
+				</div>
+				<div className={styles.legendContainer}>
+					<span className={styles.legendText}>More</span>
+					{renderLegendTiles()}
+					<span className={styles.legendText}>Less</span>
+				</div>
+				<div className={styles.modalContainer}>
+					<div className={styles.buttonContainer}>
+						<Button className={styles.btn} onClick={handleModalOpen}>What is this?</Button>
+					</div>
+					<Modal
+						open={modalOpen}
+						onClose={handleModalClose}
+						aria-labelledby="modal-title"
+						aria-describedby="modal-description"
+					>
+						<div>
+							<div className={styles.modal}>
+								<h2 id="modal-title">Daily activity</h2>
+								<p id="modal-description">
+									<br />
+									The daily activity chart is a visual display of your activity on Skool over the past year. Activities that contribute towards this chart include liking posts, writing posts, commenting on posts and voting on polls.
+									<br /><br />
+									Activities are timestamped according to Coordinated Universal Time (UTC) rather than your local time zone.
+								</p>
+
+							</div>
+						</div>
+					</Modal>
+				</div>
 			</div>
 		</div>
 	);

--- a/components/Heatmap/Heatmap.tsx
+++ b/components/Heatmap/Heatmap.tsx
@@ -1,0 +1,219 @@
+import React, { useState } from 'react';
+import { Tooltip, Modal, Button } from '@mui/material';
+import { format } from 'date-fns';
+
+import {
+	MONTHS,
+	WEEK_DAYS,
+	DAYS_IN_YEAR,
+	DEFAULT_SQUARE_GAP,
+	DEFAULT_SQUARE_SIZE,
+} from './constants';
+import {
+	getRandomCount,
+	transformCount,
+	transformPixelsToNumber,
+} from './utils';
+import styles from './Heatmap.module.css'; // Import the CSS module
+
+interface HeatmapProps {
+	colour?: string[];
+	squareNumber?: number;
+	count: number[];
+	squareGap?: string;
+	squareSize?: string;
+	fontSize?: string;
+	tooltipContent?: string;
+	data: { date: Date; activityCount: number }[];
+	registrationDate: Date;
+}
+
+const Heatmap: React.FC<HeatmapProps> = (props: HeatmapProps) => {
+	const squareNumber: number = props.squareNumber || DAYS_IN_YEAR;
+	const count: number[] = props.count || getRandomCount(squareNumber);
+	const level: number[] = count.map((i: number) => transformCount(i));
+	const squareGap: string = props.squareGap || DEFAULT_SQUARE_GAP;
+	const squareSize: string = props.squareSize || DEFAULT_SQUARE_SIZE;
+	const fontSize: string = props.fontSize || '12px';
+	const weekWidth: string =
+		String(
+			transformPixelsToNumber(squareGap) +
+			transformPixelsToNumber(squareSize)
+		) + 'px';
+
+	const [modalOpen, setModalOpen] = useState(false);
+	const [hoveredLegend, setHoveredLegend] = useState<string | null>(null);
+
+	const handleModalOpen = () => {
+		setModalOpen(true);
+	};
+
+	const handleModalClose = () => {
+		setModalOpen(false);
+	};
+
+	const handleLegendTileHover = (color: string) => {
+		setHoveredLegend(color);
+	};
+
+
+	const renderLegendTiles = () => {
+		const legendColors = ['#196127', '#239a3b', '#7bc96f', '#c6e48b', '#ebedf0'];
+
+		return legendColors.map((color) => {
+			const activityCount = getActivityCountForColor(color);
+			const tooltipContent =
+				hoveredLegend === color
+					? activityCount === 0
+						? 'No Activities'
+						: `${activityCount}+ activities`
+					: '';
+
+			return (
+				<Tooltip key={color} title={tooltipContent} arrow>
+					<div
+						className={styles.legendTile}
+						style={{ backgroundColor: color }}
+						onMouseEnter={() => handleLegendTileHover(color)}
+						onMouseLeave={() => handleLegendTileHover('null')}
+					/>
+				</Tooltip>
+			);
+		});
+	};
+
+	const getActivityCountForColor = (color: string): number => {
+		// Map legend colors to activity count using your getTileColor function
+		switch (color) {
+			case '#ebedf0':
+				return 0;
+			case '#c6e48b':
+				return 1; // Adjust the counts as per your getTileColor logic
+			case '#7bc96f':
+				return 3;
+			case '#239a3b':
+				return 6;
+			case '#196127':
+				return 10;
+			default:
+				return 0; // Default to 0 for unknown colors
+		}
+	};
+
+	// const renderTiles = () => {
+	// 	const tiles = [];
+
+	// 	for (let i = 0; i < 52; i++) {
+	// 		for (let j = 0; j < 7; j++) {
+	// 			const date = getDateForTile(i, j);
+	// 			const registrationDate = new Date(2023, 0, 1);
+
+	// 			if (date < registrationDate) {
+	// 				tiles.push(<div className={styles.placeholderTile} />);
+	// 				continue;
+	// 			}
+
+	// 			const activityData = props.data.find(
+	// 				(item) =>
+	// 					item.date.getFullYear() === date.getFullYear() &&
+	// 					item.date.getMonth() === date.getMonth() &&
+	// 					item.date.getDate() === date.getDate()
+	// 			);
+
+	// 			const isFirstDay = date.getTime() === registrationDate.getTime();
+	// 			const activityCount = activityData ? activityData.activityCount : 0;
+	// 			const tileColor = getTileColor(activityCount);
+
+	// 			tiles.push(
+	// 				<Tooltip title={getTileTooltip(date, activityCount, isFirstDay)}>
+	// 					<div
+	// 						className={styles.activityTile}
+	// 						style={{ backgroundColor: tileColor }}
+	// 					>
+	// 						{/* Added day and month labels */}
+	// 						{!isFirstDay && (
+	// 							<>
+	// 								<div className={styles.dayLabel}>
+	// 									{WEEK_DAYS[j]}
+	// 								</div>
+	// 								<div className={styles.monthLabel}>
+	// 									{MONTHS[date.getMonth()]}
+	// 								</div>
+	// 							</>
+	// 						)}
+	// 					</div>
+	// 				</Tooltip>
+	// 			);
+	// 		}
+	// 	}
+	// 	return tiles;
+	// };
+
+	return (
+		<div className={styles.Wrapper}>
+			<div className={styles.header}>
+				<p>Activity</p>
+			</div>
+			<div className={styles.Graph}>
+				<ul className={styles.Months}>
+					{MONTHS.map((month, i) => (
+						<li key={i}>{month}</li>
+					))}
+				</ul>
+				<ul className={styles.Days}>
+					{WEEK_DAYS.map((day, i) => (
+						<li key={i}>{day}</li>
+					))}
+				</ul>
+				<ul className={styles.SquaresList}>
+					{[...Array(squareNumber)].map((key: React.Key, i) => (
+						<li
+							className={`${styles.SquareListItem} ${styles.squares}`}
+							data-level={level[i]}
+							key={key}
+							data-tooltip={
+								props.tooltipContent || `${count[i]} activities`
+							}
+						></li>
+					))}
+				</ul>
+			</div>
+
+			<div className={styles.legendContainer}>
+				<span className={styles.legendText}>More</span>
+				{renderLegendTiles()}
+				<span className={styles.legendText}>Less</span>
+
+				<div className={styles.buttonContainer}>
+					<Button onClick={handleModalOpen}>What is this?</Button>
+				</div>
+				<Modal
+					open={modalOpen}
+					onClose={handleModalClose}
+					aria-labelledby="modal-title"
+					aria-describedby="modal-description"
+				>
+					<div>
+						<div className={styles.modal}>
+							<h2 id="modal-title">Daily Activity</h2>
+							<p id="modal-description">
+								Daily Activity refers to the number of activities performed by a
+								user on a given day. It is represented by the color of the tiles
+								in the graph. The darker the color, the higher the activity count.
+								The graph displays the activity count for each day of the week over
+								a period of 52 weeks. The legend on the right side of the graph
+								provides a color scale to interpret the activity levels. You can
+								hover over each tile to view the specific date and activity count.
+								Enjoy tracking your daily activities!
+							</p>
+
+							<Button onClick={handleModalClose}>Close</Button>
+						</div>
+					</div>
+				</Modal>
+			</div>
+		</div>
+	);
+};
+
+export default Heatmap;

--- a/components/Heatmap/constants.ts
+++ b/components/Heatmap/constants.ts
@@ -1,0 +1,27 @@
+export const MONTHS: string[] = [
+    'Jan',
+    'Feb',
+    'Mar',
+    'Apr',
+    'May',
+    'Jun',
+    'Jul',
+    'Aug',
+    'Sep',
+    'Oct',
+    'Nov',
+    'Dec',
+]
+
+export const WEEK_DAYS: string[] = [
+    'Mon',
+    'Wed',
+    'Fri',
+    'Sun',
+]
+
+export const DAYS_IN_YEAR: number = 365
+
+export const DEFAULT_SQUARE_GAP: string = '4px'
+
+export const DEFAULT_SQUARE_SIZE: string = '15px'

--- a/components/Heatmap/constants.ts
+++ b/components/Heatmap/constants.ts
@@ -24,4 +24,4 @@ export const DAYS_IN_YEAR: number = 365
 
 export const DEFAULT_SQUARE_GAP: string = '4px'
 
-export const DEFAULT_SQUARE_SIZE: string = '15px'
+export const DEFAULT_SQUARE_SIZE: string = '11'

--- a/components/Heatmap/utils.test.ts
+++ b/components/Heatmap/utils.test.ts
@@ -1,0 +1,37 @@
+import {
+    getRandomInt,
+    getRandomCount,
+    transformCount,
+    transformPixelsToNumber,
+} from './utils'
+
+test('getRandomInt() returns integers between the given range', () => {
+    let randomInt: number = getRandomInt(0, 10)
+    expect(randomInt).toBeGreaterThanOrEqual(0)
+    expect(randomInt).toBeLessThanOrEqual(10)
+})
+
+test('getRandomCount() returns an array of random integers between 0 and 25', () => {
+    let randomCount: number[] = getRandomCount(5)
+    expect(randomCount.length).toBe(5)
+    randomCount.forEach((count) => {
+        expect(count).toBeGreaterThanOrEqual(0)
+        expect(count).toBeLessThanOrEqual(25)
+    })
+})
+
+test('transformCount() returns the correct number of squares', () => {
+    expect(transformCount(0)).toBe(0)
+    expect(transformCount(10)).toBe(1)
+    expect(transformCount(15)).toBe(2)
+    expect(transformCount(20)).toBe(3)
+    expect(transformCount(25)).toBe(4)
+})
+
+test('transformPixelsToNumber() extracts the correct number (without unit)', () => {
+    expect(transformPixelsToNumber('0px')).toBe(0)
+    expect(transformPixelsToNumber('10rem')).toBe(10)
+    expect(transformPixelsToNumber('15em')).toBe(15)
+    expect(transformPixelsToNumber('-20px')).toBe(-20)
+    expect(transformPixelsToNumber('2520240394039304px')).toBe(2520240394039304)
+})

--- a/components/Heatmap/utils.ts
+++ b/components/Heatmap/utils.ts
@@ -1,0 +1,33 @@
+export const getRandomInt = (min: number, max: number): number => {
+    min = Math.ceil(min)
+    max = Math.floor(max)
+    let randomInt: number = Math.floor(Math.random() * (max - min + 1)) + min
+    return randomInt
+}
+
+export const getRandomCount = (squares: number) => {
+    let randomCount: number[] = []
+    for (let i = 0; i < squares; i++) {
+        randomCount.push(getRandomInt(0, 25))
+    }
+    return randomCount
+}
+
+export const transformCount = (count: number) => {
+    if (count == 0) {
+        return 0
+    } else if (count <= 10 && count !== 0) {
+        return 1
+    } else if (count > 10 && count <= 15) {
+        return 2
+    } else if (count > 15 && count <= 20) {
+        return 3
+    } else {
+        return 4
+    }
+}
+
+export const transformPixelsToNumber = (pixel: string) => {
+    let exp = /-?\d+/g
+    return parseInt(exp.exec(pixel?.toString())?.[0] ?? '0')
+}

--- a/pages/heatmap-page.tsx
+++ b/pages/heatmap-page.tsx
@@ -1,0 +1,45 @@
+import Heatmap from '@/components/Heatmap/Heatmap';
+
+const HeatmapPage = () => {
+    const registrationDate = new Date(2023, 3, 1);
+    const isFirstDay = true;
+
+    const generateHeatmapData = () => {
+        const startDate = new Date(2023, 1, 1); // Start date
+        const endDate = new Date(2023, 11, 31); // End date
+
+        const heatmapData = [];
+        const oneDay = 24 * 60 * 60 * 1000; // One day in milliseconds
+
+        const weekdays = [1, 2, 3, 4, 5]; // Monday to Friday (0 for Sunday, 1 for Monday, etc.)
+        let currentDayIndex = 0;
+
+        for (let currentDate = new Date(startDate); currentDate <= endDate; currentDate.setDate(currentDate.getDate() + 1)) {
+            const currentDayOfWeek = currentDate.getDay(); // Get the day of the week (0 for Sunday, 1 for Monday, etc.)
+
+            if (currentDayOfWeek === weekdays[currentDayIndex]) {
+                const activityCount = Math.floor(Math.random() * 20); // Random activity count between 0 and 19
+                heatmapData.push({ date: new Date(currentDate), activityCount });
+
+                currentDayIndex = (currentDayIndex + 1) % weekdays.length; // Move to the next weekday in a cyclic manner
+            }
+        }
+
+        return heatmapData;
+    };
+
+    const heatmapData = generateHeatmapData();
+
+    return (
+        <div>
+            <Heatmap
+                colour={['#ebedf0', '#c6e48b', '#40c463', '#30a14e', '#216e39']}
+                registrationDate={registrationDate}
+                data={heatmapData} // Include the data property
+                isFirstDay={isFirstDay} // Pass the isFirstDay prop
+            />
+        </div>
+    );
+};
+
+export default HeatmapPage;

--- a/pages/user-activity-page.tsx
+++ b/pages/user-activity-page.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import UserActivityGraph from '@/components/ActivityGraph/UserActivityGraph';
+
+const UserActivityPage: React.FC = () => {
+    // Mock data for testing
+    const data = [
+        { date: new Date('2022-09-15'), activityCount: 1 },
+        { date: new Date('2022-09-17'), activityCount: 8 },
+        { date: new Date('2022-09-18'), activityCount: 3 },
+        { date: new Date('2022-09-19'), activityCount: 3 },
+        { date: new Date('2023-08-01'), activityCount: 2 },
+        { date: new Date('2023-08-02'), activityCount: 5 },
+        { date: new Date('2023-08-03'), activityCount: 8 },
+        { date: new Date('2023-08-01'), activityCount: 1 },
+        { date: new Date('2023-08-05'), activityCount: 3 },
+        { date: new Date('2023-08-07'), activityCount: 2 },
+        { date: new Date('2023-08-10'), activityCount: 5 },
+        { date: new Date('2023-08-15'), activityCount: 4 },
+        { date: new Date('2023-08-22'), activityCount: 6 },
+        // Add more data here...
+
+    ];
+
+    const registrationDate = new Date('2022-09-16');
+
+    return (
+        <div>
+            <h1 style={{ fontSize: '18px', fontWeight: 'bold', marginBottom: '20px', padding: '20px' }}>Activity</h1>
+            <UserActivityGraph data={data} registrationDate={registrationDate} />
+        </div>
+    );
+};
+
+export default UserActivityPage;


### PR DESCRIPTION
Created User Activity component completing the following tasks:
- Dynamic Tiles Movement is working correctly:

Days are represented by tiles (gray-to-green-colored boxes).
Displaying 52 tiles on the x-axis, signifying the weeks in a year.
Shows exactly 7 tiles on the y-axis for days of the week. 

- Tile Varieties are working accordingly
- Display a legend with five colored tiles, each representing an activity level. 
- Hovering over these tiles should reveal a tooltip explaining the relationship between tile color and activity count (e.g., "3+ activities" for a middle-shade tile).
- "What is this?" Footnotes that opens a modal using MUI is working.
- Accepting the necessary data via props in user-activity-page.tsx
- Overall, it works correctly with the mock data, later can be connected to MongoDB to fetch User Activity data and display it.

In Progress:
- Having issues with displaying the x-axis and y-axis labels correctly, and few other small details.